### PR TITLE
Add snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: brook
 version: master
-version-script: git -C parts/cointop/build rev-parse --short HEAD
+version-script: git -C parts/brook/build rev-parse --short HEAD
 summary: Cross platform proxy software.
 description: |
   Brook is a cross-platform(Linux/MacOS/Windows/Android/iOS) proxy software 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: brook
+version: master
+version-script: git -C parts/cointop/build rev-parse --short HEAD
+summary: Cross platform proxy software.
+description: |
+  Brook is a cross-platform(Linux/MacOS/Windows/Android/iOS) proxy software 
+
+grade: stable
+confinement: strict
+
+parts:
+  go:
+    source-tag: go1.9.4
+  brook:
+    after: [go]
+    source: .
+    plugin: go
+    go-importpath: github.com/txthinking/brook.git
+
+apps:
+  brook:
+    command: brook
+    plugs:
+      - network
+      - network-bind


### PR DESCRIPTION
Adds snapcraft.yaml to enable building snaps of brook.

Once landed there's a few steps to hand this over to you in the store.

* You should sign up for a snap store account at https://dashboard.snapcraft.io/
* On the forum, start a thread to request the transfer of ownership of brook from me (snapcrafters) to you (or just ask me and I'll email the store team)
* Once transferred, go to our build service https://build.snapcraft.io/ and login using github. Add your brook repo, give it the registered snap name 'brook' and it will start building

That will get builds on each commit pushed to the edge channel in the store.

The next time you do a stable release , you can push it to the stable channel. This is done via the dashboard at https://dashboard.snapcraft.io/snaps/brook/revisions/

Alternatively on a linux or mac computer you can `snap install snapcraft` / `brew install snapcraft` and `snapcraft login` to the store and then `snapcraft release brook <revno> <channelname` to release directly from your terminal.

If you have any questions, I'm happy to answer them here, or use the forum linked above.