### PR TITLE
Use iphlpapi.dll for default gateway detection in windows

### DIFF
--- a/sysproxy/gateway_windows.go
+++ b/sysproxy/gateway_windows.go
@@ -1,0 +1,215 @@
+package sysproxy
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"github.com/txthinking/brook/sysproxy/internal/winhelper"
+)
+
+const bufSize = 32 * 1024 // 32KB buffer for GetAdaptersAddresses result, definitely enough
+
+// readInterfaceForGateway parses one AF_INET gateway addr from _IP_ADAPTER_ADDRESSES_LH struct and returns the next adapter in the linked list
+func readInterfaceForGateway(reader winhelper.RawPointerReader) (next winhelper.RawPointerReader, gateway string) {
+
+	/*
+		typedef struct _IP_ADAPTER_ADDRESSES_LH {
+			union {
+				ULONGLONG Alignment;
+				struct {
+				ULONG    Length;
+				IF_INDEX IfIndex;
+				};
+			};
+			struct _IP_ADAPTER_ADDRESSES_LH    *Next;
+			PCHAR                              AdapterName;
+			PIP_ADAPTER_UNICAST_ADDRESS_LH     FirstUnicastAddress;
+			PIP_ADAPTER_ANYCAST_ADDRESS_XP     FirstAnycastAddress;
+			PIP_ADAPTER_MULTICAST_ADDRESS_XP   FirstMulticastAddress;
+			PIP_ADAPTER_DNS_SERVER_ADDRESS_XP  FirstDnsServerAddress;
+			PWCHAR                             DnsSuffix;
+			PWCHAR                             Description;
+			PWCHAR                             FriendlyName;
+			BYTE                               PhysicalAddress[MAX_ADAPTER_ADDRESS_LENGTH];
+			ULONG                              PhysicalAddressLength;
+			union {
+				ULONG Flags;
+				struct {
+				ULONG DdnsEnabled : 1;
+				ULONG RegisterAdapterSuffix : 1;
+				ULONG Dhcpv4Enabled : 1;
+				ULONG ReceiveOnly : 1;
+				ULONG NoMulticast : 1;
+				ULONG Ipv6OtherStatefulConfig : 1;
+				ULONG NetbiosOverTcpipEnabled : 1;
+				ULONG Ipv4Enabled : 1;
+				ULONG Ipv6Enabled : 1;
+				ULONG Ipv6ManagedAddressConfigurationSupported : 1;
+				};
+			};
+			ULONG                              Mtu;
+			IFTYPE                             IfType;
+			IF_OPER_STATUS                     OperStatus;
+			IF_INDEX                           Ipv6IfIndex;
+			ULONG                              ZoneIndices[16];
+			PIP_ADAPTER_PREFIX_XP              FirstPrefix;
+			ULONG64                            TransmitLinkSpeed;
+			ULONG64                            ReceiveLinkSpeed;
+			PIP_ADAPTER_WINS_SERVER_ADDRESS_LH FirstWinsServerAddress;
+			PIP_ADAPTER_GATEWAY_ADDRESS_LH     FirstGatewayAddress;
+
+			// The rest part is useless, whatever:)
+
+			ULONG                              Ipv4Metric;
+			ULONG                              Ipv6Metric;
+			IF_LUID                            Luid;
+			SOCKET_ADDRESS                     Dhcpv4Server;
+			NET_IF_COMPARTMENT_ID              CompartmentId;
+			NET_IF_NETWORK_GUID                NetworkGuid;
+			NET_IF_CONNECTION_TYPE             ConnectionType;
+			TUNNEL_TYPE                        TunnelType;
+			SOCKET_ADDRESS                     Dhcpv6Server;
+			BYTE                               Dhcpv6ClientDuid[MAX_DHCPV6_DUID_LENGTH];
+			ULONG                              Dhcpv6ClientDuidLength;
+			ULONG                              Dhcpv6Iaid;
+			PIP_ADAPTER_DNS_SUFFIX             FirstDnsSuffix;
+		} IP_ADAPTER_ADDRESSES_LH, *PIP_ADAPTER_ADDRESSES_LH;
+	*/
+
+	_, reader = reader.ULongLong() // Alignment
+	next, reader = reader.Deref()  // Next
+	_, reader = reader.PChar()     // AdapterName
+	_, reader = reader.Ptr()       // FirstUnicastAddress
+	_, reader = reader.Ptr()       // FirstAnycastAddress
+	_, reader = reader.Ptr()       // FirstMulticastAddress
+	_, reader = reader.Ptr()       // FirstDnsServerAddress
+	_, reader = reader.PWChar()    // DnsSuffix
+	_, reader = reader.PWChar()    // Description
+	_, reader = reader.PWChar()    // FriendlyName
+	_, reader = reader.Bytes(8)    // PhysicalAddress[MAX_ADAPTER_ADDRESS_LENGTH=8]
+	_, reader = reader.ULong()     // PhysicalAddressLength
+	_, reader = reader.ULong()     // Flags
+	_, reader = reader.ULong()     // Mtu
+	_, reader = reader.DWord()     // IfType
+	var status int32
+	status, reader = reader.Int() // OperStatus
+	if status != 1 {
+		// Link is down.
+		// return
+	}
+	_, reader = reader.ULong() // Ipv6IfIndex
+	for i := 0; i < 16; i++ {
+		_, reader = reader.ULong() // ZoneIndices
+	}
+	_, reader = reader.Ptr()     // FirstPrefix
+	_, reader = reader.ULong64() // TransmitLinkSpeed
+	_, reader = reader.ULong64() // ReceiveLinkSpeed
+	_, reader = reader.Ptr()     // FirstWinsServerAddress
+	if !reader.IsNilPointer() {
+		var gatewayReader winhelper.RawPointerReader // Type is _IP_ADAPTER_GATEWAY_ADDRESS_LH
+		gatewayReader, _ = reader.Deref()
+
+		for {
+			/*
+				typedef struct _IP_ADAPTER_GATEWAY_ADDRESS_LH {
+				  union {
+				    ULONGLONG Alignment;
+				    struct {
+				      ULONG Length;
+				      DWORD Reserved;
+				    };
+				  };
+				  struct _IP_ADAPTER_GATEWAY_ADDRESS_LH *Next;
+				  SOCKET_ADDRESS                        Address;
+				} IP_ADAPTER_GATEWAY_ADDRESS_LH, *PIP_ADAPTER_GATEWAY_ADDRESS_LH;
+
+			*/
+			_, gatewayReader = gatewayReader.ULongLong() // Alignment
+			next, gatewayReader = gatewayReader.Deref()
+
+			var addr winhelper.RawPointerReader // Type is sockaddr_in
+			addr, gatewayReader = gatewayReader.Deref()
+
+			/*
+				typedef struct sockaddr_in {
+					#if(_WIN32_WINNT < 0x0600)
+					    short   sin_family;
+					#else //(_WIN32_WINNT < 0x0600)
+					    ADDRESS_FAMILY sin_family;
+					#endif //(_WIN32_WINNT < 0x0600)
+					    USHORT sin_port;
+					    IN_ADDR sin_addr;
+					    CHAR sin_zero[8];
+				} SOCKADDR_IN, *PSOCKADDR_IN;
+			*/
+			_, gatewayReader = gatewayReader.Int() // AddrLength
+			var family uint16
+			family, addr = addr.UShort() // sin_family
+			_, addr = addr.UShort()      // sin_port
+			if family == syscall.AF_INET {
+				gtBytes, _ := addr.Bytes(4)
+				gateway = fmt.Sprintf("%d.%d.%d.%d", gtBytes[0], gtBytes[1], gtBytes[2], gtBytes[3])
+				return
+			}
+
+			gatewayReader = next
+		}
+	}
+
+	return
+}
+
+// GetDefaultGateway returns default gateway
+func GetDefaultGateway() (string, error) {
+	h, err := syscall.LoadLibrary("iphlpapi.dll")
+	if err != nil {
+		return "", err
+	}
+	f, err := syscall.GetProcAddress(h, "GetAdaptersAddresses")
+	if err != nil {
+		return "", err
+	}
+
+	var buf [bufSize]byte
+
+	var bufSizeVar uint32 = bufSize
+
+	ret, _, _ := syscall.Syscall6(
+		uintptr(f),
+		5,
+		syscall.AF_INET, // Family AF_INET=2
+		0x0080|0x0001|0x0002|0x0004|0x0008, // Flags GAA_FLAG_INCLUDE_GATEWAYS | GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER
+		0,                                    // Reserved
+		uintptr(unsafe.Pointer(&buf)),        // buf
+		uintptr(unsafe.Pointer(&bufSizeVar)), // bufSize
+		0,
+	)
+	switch ret {
+	case 0:
+	case 8:
+		return "", errors.New("not enough memory")
+	case 87:
+		return "", errors.New("invalid parameter")
+	case 111:
+		return "", errors.New("buffer Overflow")
+	case 232:
+		return "", errors.New("no data")
+	default:
+		return "", errors.New("unknown error")
+	}
+
+	var reader winhelper.RawPointerReader
+	reader = winhelper.New(uintptr(unsafe.Pointer(&buf)), bufSize)
+	for reader.IsValid() {
+		next, gt := readInterfaceForGateway(reader)
+		if gt != "" {
+			return gt, nil
+		}
+		reader = next
+	}
+
+	_ = buf // Prevent GC of buf
+	return "", errors.New("All interfaces are consumed")
+}

--- a/sysproxy/internal/winhelper/psize_386.go
+++ b/sysproxy/internal/winhelper/psize_386.go
@@ -1,0 +1,3 @@
+package winhelper
+
+const pSize = 32 / 8

--- a/sysproxy/internal/winhelper/psize_amd64.go
+++ b/sysproxy/internal/winhelper/psize_amd64.go
@@ -1,0 +1,3 @@
+package winhelper
+
+const pSize = 64 / 8

--- a/sysproxy/internal/winhelper/type.go
+++ b/sysproxy/internal/winhelper/type.go
@@ -1,0 +1,176 @@
+package winhelper
+
+import (
+	"bytes"
+	"unsafe"
+)
+
+/*
+	Constructed based on Windows Data Types
+	Reference: https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types
+*/
+
+// RawPointerReader reads Windows Data Types using raw pointer reads
+type RawPointerReader struct {
+	underlyingPtr uintptr
+	lBound        uintptr
+	rBound        uintptr
+}
+
+// unsafePtr is a convenient function to convert the underlying pointer to a unsafe.Pointer
+func (c RawPointerReader) unsafePtr() unsafe.Pointer {
+	return unsafe.Pointer(c.underlyingPtr)
+}
+
+// offsetPtr returns a new RawPointerReader with the offset of the size of a pointer
+func (c RawPointerReader) offsetPtr() RawPointerReader {
+	return c.offset(pSize)
+}
+
+// offset8 is a convenient function to offset the reader by 1 byte
+func (c RawPointerReader) offset8() RawPointerReader {
+	return c.offset(1)
+}
+
+// offset16 is a convenient function to offset the reader by 2 byte
+func (c RawPointerReader) offset16() RawPointerReader {
+	return c.offset(2)
+}
+
+// offset32 is a convenient function to offset the reader by 4 byte
+func (c RawPointerReader) offset32() RawPointerReader {
+	return c.offset(4)
+}
+
+// offset64 is a convenient function to offset the reader by 8 byte
+func (c RawPointerReader) offset64() RawPointerReader {
+	return c.offset(8)
+}
+
+// offset returns a new RawPointerReader with x bytes of offset, reading boundaries remain unchanged
+func (c RawPointerReader) offset(x int) RawPointerReader {
+	return RawPointerReader{c.underlyingPtr + uintptr(x), c.lBound, c.rBound}
+}
+
+// Byte reads a BYTE
+func (c RawPointerReader) Byte() (ret byte, next RawPointerReader) {
+	return c.Char()
+}
+
+// Bytes reads a series of bytes of a fixed length
+func (c RawPointerReader) Bytes(length int) (ret []byte, next RawPointerReader) {
+	ret = make([]byte, length)
+	for i := 0; i < length; i++ {
+		ret[i], c = c.Byte()
+	}
+	next = c
+	return
+}
+
+// PChar reads a PCHAR into a string
+func (c RawPointerReader) PChar() (ret string, next RawPointerReader) {
+	next = c.offsetPtr()
+
+	r := bytes.NewBuffer([]byte{})
+	c, next = c.Deref()
+	var b byte
+	for {
+		b, c = c.Char()
+		if b == 0 {
+			break
+		}
+		r.WriteByte(b)
+	}
+	return r.String(), next
+}
+
+// Char reads a CHAR
+func (c RawPointerReader) Char() (ret byte, next RawPointerReader) {
+	return *(*byte)(c.unsafePtr()), c.offset8()
+}
+
+// PWChar reads a PWCHAR into a string
+func (c RawPointerReader) PWChar() (ret string, next RawPointerReader) {
+	next = c.offsetPtr()
+
+	r := bytes.NewBuffer([]byte{})
+	c, _ = c.Deref()
+	var b rune
+	for {
+		b, c = c.WChar()
+		if b == 0 {
+			break
+		}
+		r.WriteRune(b)
+	}
+	return r.String(), next
+}
+
+// WChar reads a WCHAR
+func (c RawPointerReader) WChar() (ret rune, next RawPointerReader) {
+	val, next := c.Word()
+	return rune(val), next
+}
+
+// Int reads a INT
+func (c RawPointerReader) Int() (ret int32, next RawPointerReader) {
+	return *(*int32)(c.unsafePtr()), c.offset32()
+}
+
+// Ushort reads a USHORT
+func (c RawPointerReader) UShort() (ret uint16, next RawPointerReader) {
+	return c.Word()
+}
+
+// Word reads a WORD
+func (c RawPointerReader) Word() (ret uint16, next RawPointerReader) {
+	return *(*uint16)(c.unsafePtr()), c.offset16()
+}
+
+// DWord reads a DWORD
+func (c RawPointerReader) DWord() (ret uint32, next RawPointerReader) {
+	return c.ULong()
+}
+
+// ULong reads a ULONG
+func (c RawPointerReader) ULong() (ret uint32, next RawPointerReader) {
+	return *(*uint32)(c.unsafePtr()), c.offset32()
+}
+
+// ULong64 reads a ULONG64
+func (c RawPointerReader) ULong64() (ret uint64, next RawPointerReader) {
+	return c.ULongLong()
+}
+
+// ULongLong reads a ULONGLONG
+func (c RawPointerReader) ULongLong() (ret uint64, next RawPointerReader) {
+	return *(*uint64)(c.unsafePtr()), c.offset64()
+}
+
+// Deref interprets the current pointer as a pointer value and dereferences to a new RawPointerReader, reading boundaries remain unchanged
+// the returned reader might not be valid, so check for validity using IsValid before accessing them, or an unrecoverable panic would occur
+func (c RawPointerReader) Deref() (ret RawPointerReader, next RawPointerReader) {
+	ptr := *((*uintptr)(c.unsafePtr()))
+	return RawPointerReader{ptr, c.lBound, c.rBound}, c.offsetPtr()
+}
+
+// IsValid checks if the current pointer position is in the reading boundaries
+func (c RawPointerReader) IsValid() bool {
+	return !(c.lBound > c.underlyingPtr || c.rBound < c.underlyingPtr)
+}
+
+// IsNilPointer is a convenient function to check if the memory address referenced at the current pointer is in the reading boundaries
+func (c RawPointerReader) IsNilPointer() bool {
+	ptr, _ := c.Deref()
+	return !ptr.IsValid()
+}
+
+// Ptr returns the underlying pointer of the RawPointerReader as an unsafe.Pointer
+func (c RawPointerReader) Ptr() (ret unsafe.Pointer, next RawPointerReader) {
+	return c.unsafePtr(), c.offsetPtr()
+}
+
+// New creates a RawPointerReader of using a pointer to an existing type
+func New(ptr uintptr, size int) RawPointerReader {
+	return RawPointerReader{ptr, ptr, ptr + uintptr(size-1)}
+}

--- a/sysproxy/system_windows.go
+++ b/sysproxy/system_windows.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net"
 	"os/exec"
-	"regexp"
 	"syscall"
 )
 
@@ -98,23 +97,4 @@ func SetDNSServer(server string) error {
 		}
 	}
 	return nil
-}
-
-// GetDefaultGateway returns default gateway
-func GetDefaultGateway() (string, error) {
-	c := exec.Command("netsh", "interface", "ipv4", "show", "address")
-	c.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	out, err := c.CombinedOutput()
-	if err != nil {
-		return "", errors.New(string(out) + err.Error())
-	}
-	r, err := regexp.Compile(`Default Gateway.*?(\d+.\d+\.\d+\.\d+)`)
-	if err != nil {
-		return "", err
-	}
-	ss := r.FindStringSubmatch(string(out))
-	if len(ss) == 0 {
-		return "", errors.New("Can not find default gateway")
-	}
-	return ss[1], nil
 }


### PR DESCRIPTION
This fixes #457

Changes proposed in this pull request:
- Used a windows API to determine the default gateway as proposed by @Arktische in #457.

Reference:
- https://docs.microsoft.com/en-us/windows/desktop/api/iphlpapi/nf-iphlpapi-getadaptersaddresses

@txthinking @Arktische

