### PR TITLE
Support custom dns in vpn mode

### DIFF
--- a/cli/brook/main.go
+++ b/cli/brook/main.go
@@ -304,6 +304,11 @@ func main() {
 					Name:  "password, p",
 					Usage: "Server password",
 				},
+				cli.StringFlag{
+					Name:  "dns, d",
+					Value: "8.8.8.8",
+					Usage: "DNS Server, like: 8.8.8.8",
+				},
 				cli.IntFlag{
 					Name:  "tcpTimeout",
 					Value: 60,
@@ -353,7 +358,7 @@ func main() {
 				if debug {
 					enableDebug()
 				}
-				return brook.RunVPN(c.String("listen"), c.String("server"), c.String("password"), c.Int("tcpTimeout"), c.Int("tcpDeadline"), c.Int("udpDeadline"), c.Int("udpSessionTime"), c.String("tunDevice"), c.String("tunIP"), c.String("tunGateway"), c.String("tunMask"))
+				return brook.RunVPN(c.String("listen"), c.String("server"), c.String("password"), c.String("dns"), c.Int("tcpTimeout"), c.Int("tcpDeadline"), c.Int("udpDeadline"), c.Int("udpSessionTime"), c.String("tunDevice"), c.String("tunIP"), c.String("tunGateway"), c.String("tunMask"))
 			},
 		},
 		cli.Command{

--- a/run.go
+++ b/run.go
@@ -123,8 +123,8 @@ func RunSystemProxy(remove bool, pac string) error {
 }
 
 // RunVPN used to make a new VPN and start.
-func RunVPN(address, server, password string, tcpTimeout, tcpDeadline, udpDeadline, udpSessionTime int, tunDevice, tunIP, tunGateway, tunMask string) error {
-	v, err := NewVPN(address, server, password, tcpTimeout, tcpDeadline, udpDeadline, udpSessionTime, tunDevice, tunIP, tunGateway, tunMask)
+func RunVPN(address, server, password, dns string, tcpTimeout, tcpDeadline, udpDeadline, udpSessionTime int, tunDevice, tunIP, tunGateway, tunMask string) error {
+	v, err := NewVPN(address, server, password, dns, tcpTimeout, tcpDeadline, udpDeadline, udpSessionTime, tunDevice, tunIP, tunGateway, tunMask)
 	if err != nil {
 		return err
 	}

--- a/vpn.go
+++ b/vpn.go
@@ -39,7 +39,7 @@ type VPN struct {
 }
 
 // NewVPN.
-func NewVPN(addr, server, password string, tcpTimeout, tcpDeadline, udpDeadline, udpSessionTime int, tunDevice, tunIP, tunGateway, tunMask string) (*VPN, error) {
+func NewVPN(addr, server, password, dns string, tcpTimeout, tcpDeadline, udpDeadline, udpSessionTime int, tunDevice, tunIP, tunGateway, tunMask string) (*VPN, error) {
 	ds, err := sysproxy.GetDNSServers()
 	if err != nil {
 		return nil, err
@@ -70,15 +70,16 @@ func NewVPN(addr, server, password string, tcpTimeout, tcpDeadline, udpDeadline,
 	if err != nil {
 		return nil, err
 	}
-	tl, err := NewTunnel("127.0.0.1:53", "8.8.8.8:53", server, password, tcpTimeout, tcpDeadline, udpDeadline)
+	dnsserver := net.JoinHostPort(dns, "53")
+	tl, err := NewTunnel("127.0.0.1:53", dnsserver, server, password, tcpTimeout, tcpDeadline, udpDeadline)
 	if err != nil {
 		return nil, err
 	}
-	f, err := tun.OpenTunDevice(tunDevice, tunIP, tunGateway, tunMask, []string{"8.8.8.8"})
+	f, err := tun.OpenTunDevice(tunDevice, tunIP, tunGateway, tunMask, []string{dns})
 	if err != nil {
 		return nil, err
 	}
-	t := gotun2socks.New(f, addr, []string{"8.8.8.8"}, false, true)
+	t := gotun2socks.New(f, addr, []string{dns}, false, true)
 	return &VPN{
 		Client:             c,
 		Tunnel:             tl,


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- The default DNS server is 8.8.8.8 and does not support modification in VPN mode. But sometimes we need to specify a DNS server, such as in an intranet environment.

@mentions
