### PR TITLE
Update buildAll.sh to fix "illegal instruction"

### DIFF
--- a/cli/brook/buildAll.sh
+++ b/cli/brook/buildAll.sh
@@ -6,8 +6,8 @@ GOOS=linux GOARCH=arm64 go build -o brook_linux_arm64 .
 GOOS=linux GOARCH=arm GOARM=7 go build -o brook_linux_arm7 .
 GOOS=linux GOARCH=arm GOARM=6 go build -o brook_linux_arm6 .
 GOOS=linux GOARCH=arm GOARM=5 go build -o brook_linux_arm5 .
-GOOS=linux GOARCH=mips go build -o brook_linux_mips .
-GOOS=linux GOARCH=mipsle go build -o brook_linux_mipsle .
+GOOS=linux GOARCH=mips GOMIPS=softfloat go build -o brook_linux_mips .
+GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -o brook_linux_mipsle .
 GOOS=linux GOARCH=mips64 go build -o brook_linux_mips64 .
 GOOS=linux GOARCH=mips64le go build -o brook_linux_mips64le .
 GOOS=linux GOARCH=ppc64 go build -o brook_linux_ppc64 .


### PR DESCRIPTION
Update buildAll.sh to fix the runtime: illegal instruction on mips (mipsle) platform.

Fixes [#68](https://github.com/txthinking/brook/issues/68#issuecomment-357819701).

Changes proposed in this pull request:
- fix the runtime: illegal instruction on mips (mipsle) platform.

@txthinking @Arktische
