### PR TITLE
Add error checking where err variable was assigned but not checked

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -134,6 +134,9 @@ func Decrypt(p, b []byte) (a byte, addr, port, data []byte, err error) {
 		return
 	}
 	k, err := GetKey(p, b[0:12])
+	if err != nil {
+		return
+	}
 	bb, err := x.AESGCMDecrypt(b[12:], k, b[0:12])
 	if err != nil {
 		return


### PR DESCRIPTION
Fixes an assigned error variable which was not checked and then was reassigned.

I did not create an issue for this PR as I felt it did not fit into any category. 