### PR TITLE
Added dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Changes proposed in this pull request:
- Added dependabot to keep go dependencies & actions updated.

Proposed Followup:
* Use GitHub actions instead of travis ci.